### PR TITLE
render links in Tweets nicely, make clickable

### DIFF
--- a/frontend/src/components/TweetContent.jsx
+++ b/frontend/src/components/TweetContent.jsx
@@ -5,11 +5,25 @@ function TweetContent({ tweet }) {
   const renderText = (text) => {
     const hashtagRegex = /(#\w+)/g; // match on # followed by 1 or more letters, numbers, or underscores
     const usernameRegex = /(@[\w]+)/g; // match on @ followed by 1 or more letters, numbers, or underscores
+    const urlRegex = /(https?:\/\/[^\s]+)/g; // match on http(s) followed by :// and non-whitespace characters
 
-    const parts = text.split(/(#\w+|@\w+)/);
+    const parts = text.split(/(#\w+|@\w+|https?:\/\/[^\s]+)/);
 
     return parts.map((part, index) => {
-      if (part.match(hashtagRegex)) {
+      if (part.match(urlRegex)) {
+        const displayText =
+          part.replace(/^https?:\/\/(www\.)?/, "").slice(0, 33) + // update bot logic if you change URL display len
+          (part.length > 33 ? "..." : "");
+        return (
+          <a
+            key={index}
+            href={part}
+            className="text-[#008080] underline hover:text-[#00abab]"
+          >
+            {displayText}
+          </a>
+        );
+      } else if (part.match(hashtagRegex)) {
         const hashtag = part.slice(1);
         return (
           <a


### PR DESCRIPTION
Recent changes to the NYT bots mean their text outputs now include the URL for viewing the article. This PR detects URLs in TweetContent, shortens them, and renders them as <a>s.

<img width="663" alt="Screenshot 2024-08-08 at 9 28 15 AM" src="https://github.com/user-attachments/assets/b331cbfd-a70e-461f-86c0-28a3e2e93052">
