### PR TITLE
adds time travel for timeline

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,9 +34,10 @@ const GlobalStyles = createGlobalStyle`
 function App() {
   const leftSidebarOptions = [
     { text: "Timeline", path: "/timeline" },
+    { text: "Time Travel", path: "/time-travel" },
     { text: "About", path: "/" },
   ];
-
+  
   const rightSidebarOptions = [];
 
   // we hack in a query param to render images in fixed dimensions for use by url screenshotting api as a pseudo og image
@@ -54,7 +55,6 @@ function App() {
     );
   }
 
-
   return (
     <ErrorBoundary>
       <MetaTags />
@@ -62,7 +62,7 @@ function App() {
       <ThemeProvider theme={original}>
         <GlobalStyles />
         <div className="app">
-          <Sidebar className="sidebarLeft" options={leftSidebarOptions} />
+          <Sidebar className="sidebarLeft" options={leftSidebarOptions}/>
           <div className="middle">
             <Outlet />
           </div>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -2,7 +2,7 @@ import "./Sidebar.css";
 /* eslint-disable react/prop-types */
 import SidebarOption from "./SidebarOption";
 
-function Sidebar({ options, className, children }) {
+function Sidebar({ options, className, children}) {
   return (
     <div className={`sidebar ${className}`}>
       {children}

--- a/frontend/src/components/TimeTravel.jsx
+++ b/frontend/src/components/TimeTravel.jsx
@@ -23,7 +23,7 @@ function TimeTravel() {
     if (attemptedFakeTime > maxFakeTime) {
       setError("Sorry, the simulation has only run until " + maxFakeTime.toDateString());
       
-      // clear after a second
+      // clear after a bit
       setTimeout(() => {
         setError(null);
       }, 5000);

--- a/frontend/src/components/TimeTravel.jsx
+++ b/frontend/src/components/TimeTravel.jsx
@@ -1,0 +1,46 @@
+import {DatePicker__UNSTABLE} from "react95"
+import { useState, useEffect } from "react";
+import { toFake } from "../services/database";
+
+function TimeTravel() {  
+
+  const queryParams = new URLSearchParams(location.search);
+  let fakeTime = queryParams.get("fakeTime");
+  const maxFakeTime = toFake(new Date())
+
+  const startingDate = fakeTime ? fakeTime.split("T")[0] : maxFakeTime.toDateString().split("T")[0]
+  let [date, setDate] = useState(startingDate);
+  let [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (fakeTime) {
+      setDate(fakeTime.split("T")[0]);
+    }
+  }, [fakeTime]);
+
+  function onAccept(date) {
+    const attemptedFakeTime = new Date(date)
+    if (attemptedFakeTime > maxFakeTime) {
+      setError("Sorry, the simulation has only run until " + maxFakeTime.toDateString());
+      
+      // clear after a second
+      setTimeout(() => {
+        setError(null);
+      }, 5000);
+
+      return;
+    }
+
+    const newFakeTime = new Date(date)
+    window.location.href = "/timeline?fakeTime=" + newFakeTime.toISOString();
+  }
+  
+  return (
+    <div classname="banner align-middle mt-4">
+      <DatePicker__UNSTABLE onAccept={onAccept} date={date}> </DatePicker__UNSTABLE>
+      {error && <p className="text-red-200 font-bold text-lg bg-red-500 p-1">{error}</p>}
+    </div>
+  );
+}
+
+export default TimeTravel;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -7,6 +7,7 @@ import Feed from "./components/Feed.jsx";
 import HashtagFeed from "./components/HashtagFeed.jsx";
 import HomePage from "./components/HomePage.jsx";
 import TweetPage from "./components/TweetPage.jsx";
+import TimeTravel from "./components/TimeTravel.jsx";
 import "./App.css";
 
 const router = createBrowserRouter([
@@ -25,6 +26,9 @@ const router = createBrowserRouter([
       {
         path: "timeline",
         element: <Feed />,
+      },
+      { path: "time-travel", 
+        element: <TimeTravel /> 
       },
       {
         path: "hashtag/:hashtagText",


### PR DESCRIPTION
this is the most simple time travel implementation

IE the "more complex" way to do it is to hard-pin the fakeTime across all pages so no matter where a user navigates, they're still time traveling.

This isn't that. This is just a 95 style date picker for jumping to the timeline page at that timestamp. Seemed to be an 80/20 solution.

Tested, it works. Guardrails:
- users can't jump to any date ahead of the simulation