### PR TITLE
move screenshot to common and add endpoint to fetch any tweet's OG

### DIFF
--- a/backend/bots/real_twitter_bot.py
+++ b/backend/bots/real_twitter_bot.py
@@ -115,29 +115,9 @@ def go(
     if dryrun:
         print(f"Would have reposted the following tweet:\n{viral_tweet['text']}")
     else:
-        image_bytes = screenshot_tweet(viral_tweet_id)
+        image_bytes = common.screenshot_tweet(viral_tweet_id)
         post_to_real_twitter(viral_tweet, author, image_bytes)
         tweet_cache[viral_tweet_id] = True
-    
-
-def screenshot_tweet(tweet_id):
-    # Take screenshot or use cached screenshot
-    image_cache_id = f"screenshot-{tweet_id}.jpg"
-    image_bytes = tweet_cache.get(image_cache_id)
-    if image_bytes is None:
-        print("No image cache found, fetching from screenshotone")
-        api_key = os.getenv("SCREENSHOTONE_API_KEY")
-        screenshot_url = f"https://api.screenshotone.com/take?access_key={api_key}&url=https%3A%2F%2Fwww.twitter-95.com%2Ftweet%2F{tweet_id}%3Frender_as_og%3Dtrue&full_page=false&viewport_width=800&viewport_height=450&device_scale_factor=3&format=jpg&image_quality=80&block_ads=true&block_cookie_banners=true&block_banners_by_heuristics=false&block_trackers=true&delay=3&timeout=60"
-        response = requests.get(screenshot_url)
-        if response.status_code == 200:
-            image_bytes = response.content
-            tweet_cache[image_cache_id] = image_bytes
-        else:
-            raise Exception(f"Error fetching image: {response.status_code}")
-    else: 
-        print("Image cache found, not fetching from screenshotone")
-
-    return image_bytes
 
 @app.local_entrypoint()
 def main(

--- a/backend/common/__init__.py
+++ b/backend/common/__init__.py
@@ -1,8 +1,8 @@
 import modal
 
-from .utils import to_fake, to_real
+from .utils import to_fake, to_real, screenshot_tweet
 
 mount = modal.Mount.from_local_python_packages("common")
 
 
-__all__ = ["to_fake", "to_real", "mount"]
+__all__ = ["to_fake", "to_real", "mount", "screenshot_tweet"]

--- a/backend/common/utils.py
+++ b/backend/common/utils.py
@@ -1,8 +1,10 @@
 from datetime import datetime, timedelta
 import re
+import os
+import modal
+import requests
 
 delta = timedelta(seconds=915_235_088)  # rough number of seconds from 1995 to 2024
-
 
 def to_fake(real_time: datetime) -> datetime:
     fake_time = real_time - delta
@@ -14,10 +16,30 @@ def to_real(fake_time: datetime) -> datetime:
     real_time = fake_time + delta
     return real_time
 
-
 def extract_hashtags(text):
     hashtag_pattern = (
         r"#\w+"  # starts with a #, then any number of letters, digits, or underscores
     )
     hashtags = set(re.findall(hashtag_pattern, text))
     return hashtags
+
+screenshot_cache = modal.Dict.from_name("screnshot-cache", create_if_missing=True)
+
+def screenshot_tweet(tweet_id):
+    # Take screenshot or use cached screenshot
+    image_cache_id = f"{tweet_id}.jpg"
+    image_bytes = screenshot_cache.get(image_cache_id)
+    if image_bytes is None:
+        print("No image cache found, fetching from screenshotone")
+        api_key = os.getenv("SCREENSHOTONE_API_KEY")
+        screenshot_url = f"https://api.screenshotone.com/take?access_key={api_key}&url=https%3A%2F%2Fwww.twitter-95.com%2Ftweet%2F{tweet_id}%3Frender_as_og%3Dtrue&full_page=false&viewport_width=800&viewport_height=450&device_scale_factor=3&format=jpg&image_quality=80&block_ads=true&block_cookie_banners=true&block_banners_by_heuristics=false&block_trackers=true&delay=3&timeout=60"
+        response = requests.get(screenshot_url)
+        if response.status_code == 200:
+            image_bytes = response.content
+            screenshot_cache[image_cache_id] = image_bytes
+        else:
+            raise Exception(f"Error fetching image: {response.status_code}")
+    else: 
+        print("Image cache found, not fetching from screenshotone")
+
+    return image_bytes

--- a/frontend/src/components/Tweet.jsx
+++ b/frontend/src/components/Tweet.jsx
@@ -45,9 +45,8 @@ function Tweet({ tweet, showStats, showQuoted = true }) {
   };
 
   const handleRetweetClick = () => {
-
     fakeTime = tweet.fake_time + 1000;
-    const url = `https://twitter-95.com/profile/${author.user_name}?fakeTime=${fakeTime}`
+    const url = `https://twitter-95.com/tweet/${tweet.tweet_id}`
     const text = `Check out this tweet from 1995 by ${author.user_name}:%0A%0A${url}`
     const tweetContent = `https://x.com/intent/post?text=${text}`
     window.open(tweetContent, '_blank');``

--- a/frontend/src/services/database.js
+++ b/frontend/src/services/database.js
@@ -54,6 +54,11 @@ const getTweet = async (tweetId) => {
   return tweet;
 };
 
+const getOgImageUrl = (tweetId) => {
+  console.log("OG Image URL", `${baseUrl}/tweet/${tweetId}/og.jpg`);
+  return `${baseUrl}/tweet/${tweetId}/og.jpg`;
+}
+
 const getPosts = async (userName, fakeTime, limit) => {
   const params = new URLSearchParams();
   params.append("user_name", userName);
@@ -95,4 +100,4 @@ const getTrending = async (fakeTime, limit) => {
   return trendingHashtags;
 };
 
-export { getTimeline, getTweet, getPosts, getProfile, getHashtag, getTrending, toFake };
+export { getTimeline, getTweet, getPosts, getProfile, getHashtag, getTrending, toFake, getOgImageUrl };


### PR DESCRIPTION
Tried to fully add OG image rendering to the Tweet URL Intent of the "repost" button but since it's a SPA we can't dynamically set meta tags. 

but the API's /tweet/:tweetID/og.jpg route may be useful still!