### PR TITLE
extends the timeout on user_agent.go calls to handle vLLM cold boots

### DIFF
--- a/backend/bots/user_agent.py
+++ b/backend/bots/user_agent.py
@@ -11,6 +11,9 @@ import common
 from bots.common import Client
 
 
+MINUTES = 60
+
+
 image = modal.Image.debian_slim(python_version="3.11").pip_install(
     "openai", "instructor"
 )
@@ -44,6 +47,7 @@ class DoNothing(BaseModel):
     image=image,
     secrets=[modal.Secret.from_name("vllm-secret")],
     schedule=modal.Period(minutes=10),
+    timeout=60 * MINUTES,
 )
 def go(
     user_name: Optional[int] = None,


### PR DESCRIPTION
iiuc, we can end up in a crash loop situation if our functions timeout before the vLLM server can handle them -- it looks like the server gets a kill signal when inputs timeout, which then cascades into more timeouts from cold boots. if that's correct, we should interdict that signal. in the meantime, just boost the timeout to much longer than queue + boot + request handling