### PR TITLE
setup NYT frontpage backfill

### DIFF
--- a/backend/bots/backfill.py
+++ b/backend/bots/backfill.py
@@ -2,18 +2,19 @@ from datetime import datetime, timedelta
 
 import modal
 
-app = modal.App("user_agent_backfill")
+app = modal.App("backfill")
 
 
 @app.local_entrypoint()
 def main(
+    app_name: str,
+    function_name: str,
     start_time: str,
     end_time: str,
-    verbose: bool = True,
     dryrun: bool = True,
     delta: int = 10,
 ):
-    post = modal.Function.lookup("user_agent", "go")
+    post = modal.Function.lookup(app_name, function_name)
 
     start_time = datetime.strptime(start_time, "%Y-%m-%d %H:%M")
     end_time = datetime.strptime(end_time, "%Y-%m-%d %H:%M")
@@ -24,8 +25,7 @@ def main(
         current_time += timedelta(minutes=delta)
 
     handles = [
-        post.spawn(verbose=verbose, dryrun=dryrun, fake_time=fake_time)
-        for fake_time in datetimes
+        post.spawn(dryrun=dryrun, fake_time=fake_time) for fake_time in datetimes
     ]
 
     for handle in handles:

--- a/backend/bots/nyt/frontpage.py
+++ b/backend/bots/nyt/frontpage.py
@@ -65,11 +65,15 @@ def accept_article(article):
     try:
         if (
             article["type_of_material"] in ["News", "Op-Ed"]  # news
-            and article["print_section"] == "A"  # front section
+            and article["print_section"] in ["A", "1"]  # front section
             and len(article["lead_paragraph"].strip()) >= 20
             and "was married" not in article["lead_paragraph"]
         ):
-            if article["headline"]["main"].strip().upper() != "NO HEADLINE":
+            if article["headline"]["main"].strip().upper() not in [
+                "NO HEADLINE",
+                "INSIDE",
+                "NEWS SUMMARY",
+            ]:
                 return True
         else:
             print("article skipped")
@@ -79,4 +83,6 @@ def accept_article(article):
 
 @app.local_entrypoint()
 def main(fake_time: str = None, lookahead_hours: int = None, dryrun: bool = True):
-    post_nyt_articles.remote(fake_time, lookahead_hours, dryrun=dryrun)
+    post_nyt_articles.remote(
+        datetime.fromisoformat(fake_time), lookahead_hours, dryrun=dryrun
+    )


### PR DESCRIPTION
works on posts from January (live run, below) and recent posts (dryrun, not pictured)

<img width="1510" alt="Screenshot 2024-08-10 at 3 13 31 PM" src="https://github.com/user-attachments/assets/c6f4b173-f6bd-43a9-9479-273a3608f7e2">
