### PR TITLE
hold fakeTime in state

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,7 +9,8 @@ import ErrorBoundary from "./components/ErrorBoundary";
 import Trending from "./components/Trending";
 import MetaTags from "./components/MetaTags";
 import { FakeTimeContext } from './components/FakeTimeContext';
-import { useContext } from "react";
+import { useContext, useEffect} from "react";
+import { useNavigate } from "react-router-dom";
 
 import ms_sans_serif from "react95/dist/fonts/ms_sans_serif.woff2";
 import ms_sans_serif_bold from "react95/dist/fonts/ms_sans_serif_bold.woff2";
@@ -35,6 +36,7 @@ const GlobalStyles = createGlobalStyle`
 `;
 
 function App() {
+  const navigate = useNavigate();
 
   const leftSidebarOptions = [
     { text: "Timeline", path: "/timeline" },
@@ -73,6 +75,19 @@ function App() {
     navigate("/timeline");
   }
 
+  // cmd+k to go to time travel
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+        navigate("/time-travel");
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
   return (
     <ErrorBoundary>
       <MetaTags />
@@ -85,8 +100,8 @@ function App() {
             {displayTimeTravel && <div className="fixed bottom-0 left-0 w-full z-50">
               <p className="bg-[#7FEE64] py-1 text-black ">
                 Currently viewing from {new Date(formatTime(fakeTime)).toDateString()}, 
-                <a className="underline cursor-pointer hover:text-gray-500" onClick={resetTimeTravel}>
-                  click here to reset
+                <a className="underline cursor-pointer hover:text-gray-500 ml-1" onClick={resetTimeTravel}>
+                click here to reset
                 </a>
               </p>
             </div> 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -82,7 +82,6 @@ function App() {
         <div className="app">
           <Sidebar className="sidebarLeft" options={leftSidebarOptions}/>
           <div className="middle">
-            {/* /* make this a sticky footer  */}
             {displayTimeTravel && <div className="fixed bottom-0 left-0 w-full z-50">
               <p className="bg-[#7FEE64] py-1 text-black ">
                 Currently viewing from {new Date(formatTime(fakeTime)).toDateString()}, 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,9 +8,12 @@ import original from "react95/dist/themes/original";
 import ErrorBoundary from "./components/ErrorBoundary";
 import Trending from "./components/Trending";
 import MetaTags from "./components/MetaTags";
+import { FakeTimeContext } from './components/FakeTimeContext';
+import { useContext } from "react";
 
 import ms_sans_serif from "react95/dist/fonts/ms_sans_serif.woff2";
 import ms_sans_serif_bold from "react95/dist/fonts/ms_sans_serif_bold.woff2";
+import { formatTime, fakeNow } from "./services/database";
 
 const GlobalStyles = createGlobalStyle`
   ${styleReset}
@@ -32,6 +35,7 @@ const GlobalStyles = createGlobalStyle`
 `;
 
 function App() {
+
   const leftSidebarOptions = [
     { text: "Timeline", path: "/timeline" },
     { text: "Time Travel", path: "/time-travel" },
@@ -55,6 +59,20 @@ function App() {
     );
   }
 
+  const { fakeTime, setFakeTime } = useContext(FakeTimeContext);
+  const currentFakeTime = fakeNow();
+  let displayTimeTravel = false;
+  const hr = 60 * 60 * 1000;
+  if (new Date(fakeTime) < currentFakeTime - hr){
+    displayTimeTravel = true;
+  }
+
+  function resetTimeTravel() {
+    const newFakeTime = fakeNow();
+    setFakeTime(newFakeTime.toISOString());
+    navigate("/timeline");
+  }
+
   return (
     <ErrorBoundary>
       <MetaTags />
@@ -64,6 +82,16 @@ function App() {
         <div className="app">
           <Sidebar className="sidebarLeft" options={leftSidebarOptions}/>
           <div className="middle">
+            {/* /* make this a sticky footer  */}
+            {displayTimeTravel && <div className="fixed bottom-0 left-0 w-full z-50">
+              <p className="bg-[#7FEE64] py-1 text-black ">
+                Currently viewing from {new Date(formatTime(fakeTime)).toDateString()}, 
+                <a className="underline cursor-pointer hover:text-gray-500" onClick={resetTimeTravel}>
+                  click here to reset
+                </a>
+              </p>
+            </div> 
+            }
             <Outlet />
           </div>
           <Sidebar className="sidebarRight" options={rightSidebarOptions}>

--- a/frontend/src/components/FakeTimeContext.jsx
+++ b/frontend/src/components/FakeTimeContext.jsx
@@ -1,0 +1,13 @@
+import React, { createContext, useState } from 'react';
+import { fakeNow } from '../services/database';
+
+export const FakeTimeContext = createContext();
+export const FakeTimeProvider = ({ children }) => {
+  const [fakeTime, setFakeTime] = useState(fakeNow().toISOString());
+
+  return (
+    <FakeTimeContext.Provider value={{ fakeTime, setFakeTime }}>
+      {children}
+    </FakeTimeContext.Provider>
+  );
+};

--- a/frontend/src/components/Feed.jsx
+++ b/frontend/src/components/Feed.jsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useContext } from "react";
 import { getTimeline } from "../services/database";
+import { FakeTimeContext } from './FakeTimeContext';
 import { useLocation } from "react-router-dom";
 import Tweet from "./Tweet";
-import TweetCount from "./TweetCount";
 import Loading from "./Loading";
 
 function Feed() {
@@ -10,8 +10,14 @@ function Feed() {
   const [tweets, setTweets] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
 
+
+  const { fakeTime, setFakeTime } = useContext(FakeTimeContext);
+  // any url param will set the fakeTime in the browsing session
   const queryParams = new URLSearchParams(location.search);
-  const fakeTime = queryParams.get("fakeTime");
+  if (queryParams.get("fakeTime")) {
+    setFakeTime(queryParams.get("fakeTime"));
+  }
+
   const userId = queryParams.get("userId");
 
   useEffect(() => {

--- a/frontend/src/components/HashtagFeed.jsx
+++ b/frontend/src/components/HashtagFeed.jsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useContext } from "react";
 import { useParams, useLocation } from "react-router-dom";
 import { getHashtag } from "../services/database";
 import Tweet from "./Tweet";
-import TweetCount from "./TweetCount";
+import { FakeTimeContext } from './FakeTimeContext';
 import Loading from "./Loading";
 
 function HashtagFeed() {
@@ -11,8 +11,13 @@ function HashtagFeed() {
   const [tweets, setTweets] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
 
+  const { fakeTime, setFakeTime } = useContext(FakeTimeContext);
+  // any url param will set the fakeTime in the browsing session
   const queryParams = new URLSearchParams(location.search);
-  const fakeTime = queryParams.get("fakeTime");
+  if (queryParams.get("fakeTime")) {
+    setFakeTime(queryParams.get("fakeTime"));
+  }
+
   const limit = queryParams.get("limit");
 
   useEffect(() => {

--- a/frontend/src/components/HomePage.jsx
+++ b/frontend/src/components/HomePage.jsx
@@ -1,4 +1,4 @@
-import { toFake } from "../services/database";
+import { fakeNow } from "../services/database";
 
 function HomePage() {
   return (
@@ -26,7 +26,7 @@ function HomePage() {
           .<br /> <br />
         </p>
         <p>
-          In the simulation it is currently {toFake(new Date()).toDateString()}
+          In the simulation it is currently {fakeNow().toDateString()}
           .<br /> <br />
         </p>
         <p>

--- a/frontend/src/components/HomePage.jsx
+++ b/frontend/src/components/HomePage.jsx
@@ -26,7 +26,7 @@ function HomePage() {
           .<br /> <br />
         </p>
         <p>
-          In the simulation it is currently {fakeNow().toDateString()}
+          In the simulation it is currently {fakeNow().toDateString()} GMT
           .<br /> <br />
         </p>
         <p>

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useContext } from "react";
 import { useParams, useLocation } from "react-router-dom";
 import Tweet from "./Tweet";
 import User from "./User";
 import { getProfile, getPosts } from "../services/database";
 import Loading from "./Loading";
+import { FakeTimeContext } from './FakeTimeContext';
 
 function Profile() {
   const location = useLocation();
@@ -11,8 +12,13 @@ function Profile() {
   const [profile, setProfile] = useState({});
   const [isLoading, setIsLoading] = useState(false);
 
+  const { fakeTime, setFakeTime } = useContext(FakeTimeContext);
+
+  // any url param will set the fakeTime in the browsing session
   const queryParams = new URLSearchParams(location.search);
-  const fakeTime = queryParams.get("fakeTime");
+  if (queryParams.get("fakeTime")) {
+    setFakeTime(queryParams.get("fakeTime"));
+  }
 
   useEffect(() => {
     async function fetchData() {

--- a/frontend/src/components/SidebarOption.jsx
+++ b/frontend/src/components/SidebarOption.jsx
@@ -1,9 +1,17 @@
+import { useNavigate } from "react-router-dom";
+
 function SidebarOption({ Icon, text, path }) {
+  const navigate = useNavigate();
+
+  function handleClick() {
+    navigate(path);
+  }
+
   return (
     <div className="sidebarOption">
       {Icon && <Icon />}
       <h2>
-        <a href={path}>{text}</a>
+        <a onClick={handleClick}>{text}</a>
       </h2>
     </div>
   );

--- a/frontend/src/components/TimeTravel.jsx
+++ b/frontend/src/components/TimeTravel.jsx
@@ -43,7 +43,7 @@ function TimeTravel() {
       return;
     }
 
-    console.log("date", date); // treat this as UTC
+    // date is UTC like 1995-08-06
     // add 23hr, 59min, 59sec, 999ms to the end of the day
     let newFakeTime = new Date(`${date}T00:00:00.000Z`);
     newFakeTime.setUTCHours(23, 59, 59, 999);

--- a/frontend/src/components/TimeTravel.jsx
+++ b/frontend/src/components/TimeTravel.jsx
@@ -1,11 +1,20 @@
 import { DatePicker__UNSTABLE } from "react95";
-import { useState, useEffect } from "react";
-import { toFake } from "../services/database";
+import { useState, useEffect, useContext } from "react";
+import { fakeNow, formatTime } from "../services/database";
+import { FakeTimeContext } from './FakeTimeContext';
+import { useNavigate } from "react-router-dom";
 
 function TimeTravel() {
+  const navigate = useNavigate();
+
+  const { fakeTime, setFakeTime } = useContext(FakeTimeContext);
+  // any url param will set the fakeTime in the browsing session
   const queryParams = new URLSearchParams(location.search);
-  let fakeTime = queryParams.get("fakeTime");
-  const maxFakeTime = toFake(new Date());
+  if (queryParams.get("fakeTime")) {
+    setFakeTime(queryParams.get("fakeTime"));
+  }
+
+  const maxFakeTime = fakeNow();
 
   const startingDate = fakeTime
     ? fakeTime.split("T")[0]
@@ -34,8 +43,12 @@ function TimeTravel() {
       return;
     }
 
-    const newFakeTime = new Date(date);
-    window.location.href = "/timeline?fakeTime=" + newFakeTime.toISOString();
+    console.log("date", date); // treat this as UTC
+    // add 23hr, 59min, 59sec, 999ms to the end of the day
+    let newFakeTime = new Date(`${date}T00:00:00.000Z`);
+    newFakeTime.setUTCHours(23, 59, 59, 999);
+    setFakeTime(formatTime(newFakeTime.toISOString()));
+    navigate("/timeline");
   }
 
   return (

--- a/frontend/src/components/Trending.jsx
+++ b/frontend/src/components/Trending.jsx
@@ -1,16 +1,21 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useContext } from "react";
 import { getTrending } from "../services/database";
 import { useLocation } from "react-router-dom";
 import TrendingHashtag from "./TrendingHashtag";
 import Loading from "./Loading";
+import { FakeTimeContext } from './FakeTimeContext';
 
 function Trending() {
   const location = useLocation();
   const [trending, setTrending] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
 
+  const { fakeTime, setFakeTime } = useContext(FakeTimeContext);
+  // any url param will set the fakeTime in the browsing session
   const queryParams = new URLSearchParams(location.search);
-  const fakeTime = queryParams.get("fakeTime");
+  if (queryParams.get("fakeTime")) {
+    setFakeTime(queryParams.get("fakeTime"));
+  }
 
   useEffect(() => {
     async function fetchTrending() {

--- a/frontend/src/components/TrendingHashtag.jsx
+++ b/frontend/src/components/TrendingHashtag.jsx
@@ -1,7 +1,15 @@
+import { useNavigate } from "react-router-dom";
+
 function TrendingHashtag({ text }) {
+  const navigate = useNavigate();
+
+  function handleClick() {
+    navigate(`/hashtag/${text.slice(1)}`);
+  }
+
   return (
-    <div className="text-[#7FEE64] text-sm">
-      <a href={`/hashtag/${text.slice(1)}`} className="text-sm">
+    <div className="text-[#7FEE64] text-sm cursor-pointer">
+      <a onClick={handleClick} className="text-sm">
         {text}
       </a>
     </div>

--- a/frontend/src/components/Tweet.jsx
+++ b/frontend/src/components/Tweet.jsx
@@ -9,6 +9,8 @@ import {
   Button
 } from "react95";
 import TweetContent from "./TweetContent";
+import { useContext } from "react";
+import { FakeTimeContext } from './FakeTimeContext';
 
 const MenuListItem = styled(React95MenuListItem)`
   &:hover {
@@ -36,8 +38,12 @@ function Tweet({ tweet, showStats, showQuoted = true }) {
   const location = useLocation();
   const author = tweet.author;
 
+  const { fakeTime, setFakeTime } = useContext(FakeTimeContext);
+  // any url param will set the fakeTime in the browsing session
   const queryParams = new URLSearchParams(location.search);
-  let fakeTime = queryParams.get("fakeTime");
+  if (queryParams.get("fakeTime")) {
+    setFakeTime(queryParams.get("fakeTime"));
+  }
 
   const handleProfileClick = () => {
     fakeTime = tweet.fake_time + 1000;

--- a/frontend/src/components/TweetPage.jsx
+++ b/frontend/src/components/TweetPage.jsx
@@ -2,8 +2,10 @@ import { useParams } from "react-router-dom";
 import Tweet from "./Tweet";
 import { getTweet } from "../services/database";
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 function TweetPage() {
+  const navigate = useNavigate();
   // pull tweetID from url /tweet/:tweetId?render_as_og=true
   const tweetId = useParams().tweetId;
 
@@ -20,7 +22,7 @@ function TweetPage() {
         setTweet(fetched_tweet);
       } else {
         // redirect to home page
-        window.location.href = "/timeline";
+        navigate("/timeline");
       }
     }
     fetchTweet();

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { FakeTimeProvider } from "./components/FakeTimeContext";
 import Profile from "./components/Profile.jsx";
 import App from "./App.jsx";
 import Feed from "./components/Feed.jsx";
@@ -44,6 +45,8 @@ const router = createBrowserRouter([
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <FakeTimeProvider>
+      <RouterProvider router={router} />
+    </FakeTimeProvider>
   </React.StrictMode>
 );

--- a/frontend/src/services/database.js
+++ b/frontend/src/services/database.js
@@ -6,6 +6,10 @@ const baseUrl = `https://${urlPrefix}${urlSuffix}`;
 
 const deltaMilliseconds = 915235088 * 1000; // time from 1995 to 2024
 
+function fakeNow() {
+  return toFake(formatTime(new Date().toISOString()));
+}
+
 function toFake(realTime) {
   const realDate = new Date(realTime);
   const fakeTime = new Date(realDate.getTime() - deltaMilliseconds);
@@ -19,7 +23,10 @@ function toReal(fakeTime) {
 }
 
 function formatTime(time) {
-  return time.slice(0, -1);
+  if (time.slice(-1) === "Z") {
+    return time.slice(0, -1);
+  }
+  return time;
 }
 
 const fetchData = async (url) => {
@@ -108,4 +115,6 @@ export {
   getTrending,
   toFake,
   getOgImageUrl,
+  fakeNow,
+  formatTime
 };


### PR DESCRIPTION
makes it so if a user time travels, fakeTime is stored in local context rather than needing to be passed around by URL

adds sticky footer when user is time traveling.

note:
- routing redirects use navigate(path) instead of href, since href rerenders and loses state
- everything uses the "z" stripped time, basically the UTC representation. fakeNow() replaces new Date() to do this for us whenever creating a date from the client.