### PR TITLE
rename 'Time Travel' to 'Search'

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -40,7 +40,7 @@ function App() {
 
   const leftSidebarOptions = [
     { text: "Timeline", path: "/timeline" },
-    { text: "Time Travel", path: "/time-travel" },
+    { text: "Search", path: "/time-travel" },
     { text: "About", path: "/" },
   ];
 


### PR DESCRIPTION
fyi @erik-dunteman -- as much as I love time travel: it's a bit confusing next to "Timeline" and there's a breakable space in it. Could add non-breaking space, but sidebars are maybe too thin. "Search" is reasonably descriptive of what it is, will encourage clicks, and is where we aspire to end up with it, cf #31 